### PR TITLE
fix(ENG-11425): run goreleaser before changelog write-back

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,23 +56,6 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Commit files
-        env:
-          CHANGELOG: ${{ needs.cut-tag.outputs.changelog }}
-          NEW_TAG: ${{ needs.cut-tag.outputs.new_tag }}
-        run: |
-          git config --local user.email "platform@basistheory.com"
-          git config --local user.name "github-actions[bot]"
-          printf '%s\n' "$CHANGELOG" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
-          git add CHANGELOG.md
-          git commit -m "chore(release): upating changelog ${NEW_TAG} [skip ci]" || echo "Nothing to update"
-
-      - name: Push changes
-        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          branch: ${{ github.ref }}
-
       - name: Write Release Notes
         env:
           CHANGELOG: ${{ needs.cut-tag.outputs.changelog }}
@@ -90,6 +73,10 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
+      # GoReleaser must run on the tagged commit. The checkout is github.sha
+      # (== the commit cut-tag tagged), so release here BEFORE the changelog
+      # write-back — committing the changelog first moves HEAD off the tag and
+      # fails GoReleaser's git-state validation.
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
@@ -98,6 +85,21 @@ jobs:
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          # HEAD is one commit past the tag (changelog [skip ci] commit), so
-          # `git describe --exact-match` finds no tag — pin it explicitly.
           GORELEASER_CURRENT_TAG: ${{ needs.cut-tag.outputs.new_tag }}
+
+      - name: Commit files
+        env:
+          CHANGELOG: ${{ needs.cut-tag.outputs.changelog }}
+          NEW_TAG: ${{ needs.cut-tag.outputs.new_tag }}
+        run: |
+          git config --local user.email "platform@basistheory.com"
+          git config --local user.name "github-actions[bot]"
+          printf '%s\n' "$CHANGELOG" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
+          git add CHANGELOG.md
+          git commit -m "chore(release): upating changelog ${NEW_TAG} [skip ci]" || echo "Nothing to update"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           printf '%s\n' "$CHANGELOG" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
           git add CHANGELOG.md
-          git commit -m "chore(release): upating changelog ${NEW_TAG} [skip ci]" || echo "Nothing to update"
+          git commit -m "chore(release): updating changelog ${NEW_TAG} [skip ci]" || echo "Nothing to update"
 
       - name: Push changes
         uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master


### PR DESCRIPTION
## Description
- The migrated release workflow combined tag-cut and GoReleaser into one job where the changelog write-back (`Commit files` / `Push changes`) ran **before** `Run GoReleaser`, moving HEAD one commit past the version tag. GoReleaser then failed git-state validation: `git tag vX was not made against commit …`.
- Reorder so GoReleaser runs on the tagged commit (`github.sha`) first — Write Release Notes → Set up Go → Import GPG → **Run GoReleaser** → then the changelog `Commit files` / `Push changes` write-back. No token or logic changes; only step order + a clarifying comment.
- In the original (pre-migration) workflow this worked because tag-cut and release were separate jobs, so the release job's checkout was `github.sha` (the tagged commit); combining them regressed the ordering.
- Merging this also re-validates the release pipeline end-to-end: it cuts the next patch tag via `bt-version-tagger` and publishes via GoReleaser on the tagged commit, then writes the changelog back via `bt_semantic_release`.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change