### PR TITLE
fix(ENG-11539): surface provisioning errors and runtime resolutions

### DIFF
--- a/docs/resources/proxy.md
+++ b/docs/resources/proxy.md
@@ -210,3 +210,4 @@ Optional:
 - `timeout` (Number)
 - `warm_concurrency` (Number)
 
+

--- a/docs/resources/proxy.md
+++ b/docs/resources/proxy.md
@@ -166,6 +166,7 @@ Optional:
 - `dependencies` (Map of String)
 - `image` (String)
 - `permissions` (List of String)
+- `resolutions` (Map of String)
 - `resources` (String)
 - `timeout` (Number)
 - `warm_concurrency` (Number)
@@ -204,8 +205,8 @@ Optional:
 - `dependencies` (Map of String)
 - `image` (String)
 - `permissions` (List of String)
+- `resolutions` (Map of String)
 - `resources` (String)
 - `timeout` (Number)
 - `warm_concurrency` (Number)
-
 

--- a/docs/resources/reactor.md
+++ b/docs/resources/reactor.md
@@ -69,3 +69,4 @@ Optional:
 - `timeout` (Number) Timeout setting in seconds
 - `warm_concurrency` (Number) Warm concurrency setting
 
+

--- a/docs/resources/reactor.md
+++ b/docs/resources/reactor.md
@@ -64,8 +64,8 @@ Optional:
 - `dependencies` (Map of String) Runtime dependencies
 - `image` (String) Runtime image (e.g., node22)
 - `permissions` (List of String) List of permissions for the reactor
+- `resolutions` (Map of String) Runtime dependency resolutions
 - `resources` (String) Resource allocation (e.g., standard)
 - `timeout` (Number) Timeout setting in seconds
 - `warm_concurrency` (Number) Warm concurrency setting
-
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Basis-Theory/terraform-provider-basistheory
 go 1.22
 
 require (
-	github.com/Basis-Theory/go-sdk/v5 v5.1.0
+	github.com/Basis-Theory/go-sdk/v5 v5.10.0
 	github.com/hashicorp/terraform-plugin-docs v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
 	github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/Basis-Theory/go-sdk/v5 v5.1.0 h1:FyeoZ/cjlhNaoqJgeTXKwPFIFioGuRgYwiNFPdXRCa0=
 github.com/Basis-Theory/go-sdk/v5 v5.1.0/go.mod h1:8ghiVjgMwnU9UzeUfb6WYOmftUPwW1+mFE0Tbm9NHL4=
+github.com/Basis-Theory/go-sdk/v5 v5.10.0 h1:UhaMyhbeBWNMPDjve0ImN/pdCHtGkHreCQo+8j5Db3w=
+github.com/Basis-Theory/go-sdk/v5 v5.10.0/go.mod h1:8ghiVjgMwnU9UzeUfb6WYOmftUPwW1+mFE0Tbm9NHL4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=

--- a/internal/provider/resource_basistheory_apple_pay_merchant_certificates.go
+++ b/internal/provider/resource_basistheory_apple_pay_merchant_certificates.go
@@ -117,8 +117,8 @@ func resourceApplePayMerchantCertificatesCreate(ctx context.Context, data *schem
 	request := &merchantpkg.ApplePayMerchantCertificatesRegisterRequest{
 		MerchantCertificateData:             &certificateData,
 		MerchantCertificatePassword:         &password,
-		PaymentProcessorCertificateData:     &ppCertData,
-		PaymentProcessorCertificatePassword: &ppPassword,
+		PaymentProcessorCertificateData:     ppCertData,
+		PaymentProcessorCertificatePassword: ppPassword,
 		Domain:                              &domain,
 	}
 

--- a/internal/provider/resource_basistheory_proxy.go
+++ b/internal/provider/resource_basistheory_proxy.go
@@ -542,7 +542,7 @@ func waitForProxyFinalState(ctx context.Context, client *basistheoryClient.Clien
 		case "active":
 			return proxy, nil
 		case "failed", "outdated":
-			return nil, diag.Errorf("proxy %s reached failed state", id)
+			return nil, proxyFinalStateDiagnostics(id, state, proxy)
 		}
 
 		select {
@@ -551,6 +551,42 @@ func waitForProxyFinalState(ctx context.Context, client *basistheoryClient.Clien
 		case <-time.After(interval):
 		}
 	}
+}
+
+func proxyFinalStateDiagnostics(id string, state string, proxy *basistheory.Proxy) diag.Diagnostics {
+	message := "proxy %s reached %s state"
+	errorArgs := []interface{}{id, state}
+
+	requested := proxy.GetRequested()
+	if requested == nil {
+		return diag.Errorf(message, errorArgs...)
+	}
+
+	if errorCode := requested.GetErrorCode(); errorCode != nil && *errorCode != "" {
+		message += "\n\tRequested Proxy Error Code: %s"
+		errorArgs = append(errorArgs, *errorCode)
+	}
+
+	if errorMessage := requested.GetErrorMessage(); errorMessage != nil && *errorMessage != "" {
+		message += "\n\tRequested Proxy Error Message: %s"
+		errorArgs = append(errorArgs, *errorMessage)
+	}
+
+	if errorDetails := requested.GetErrorDetails(); len(errorDetails) > 0 {
+		message += "\n\tRequested Proxy Error Details: %s"
+		errorArgs = append(errorArgs, formatRequestedErrorDetails(errorDetails))
+	}
+
+	return diag.Errorf(message, errorArgs...)
+}
+
+func formatRequestedErrorDetails(errorDetails map[string]interface{}) string {
+	formattedDetails, err := json.MarshalIndent(errorDetails, "\t\t", "  ")
+	if err != nil {
+		return fmt.Sprintf("%+v", errorDetails)
+	}
+
+	return string(formattedDetails)
 }
 
 func resourceProxyRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_basistheory_proxy.go
+++ b/internal/provider/resource_basistheory_proxy.go
@@ -171,6 +171,7 @@ func resourceBasisTheoryProxy() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"image":            {Type: schema.TypeString, Optional: true},
 												"dependencies":     {Type: schema.TypeMap, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+												"resolutions":      {Type: schema.TypeMap, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
 												"warm_concurrency": {Type: schema.TypeInt, Optional: true},
 												"timeout":          {Type: schema.TypeInt, Optional: true},
 												"resources":        {Type: schema.TypeString, Optional: true},
@@ -256,6 +257,7 @@ func resourceBasisTheoryProxy() *schema.Resource {
 											Schema: map[string]*schema.Schema{
 												"image":            {Type: schema.TypeString, Optional: true},
 												"dependencies":     {Type: schema.TypeMap, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+												"resolutions":      {Type: schema.TypeMap, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
 												"warm_concurrency": {Type: schema.TypeInt, Optional: true},
 												"timeout":          {Type: schema.TypeInt, Optional: true},
 												"resources":        {Type: schema.TypeString, Optional: true},
@@ -898,6 +900,20 @@ func parseTransformsFromData(data *schema.ResourceData, fieldName string) []*bas
 											hasRuntimeData = true
 										}
 									}
+									if resolutions, ok := rtMap["resolutions"]; ok && resolutions != nil {
+										resolutionMap := map[string]*string{}
+										hasValidResolutions := false
+										for k, v := range resolutions.(map[string]interface{}) {
+											if vStr, ok := v.(string); ok && vStr != "" {
+												resolutionMap[k] = getStringPointer(v)
+												hasValidResolutions = true
+											}
+										}
+										if hasValidResolutions {
+											rt.Resolutions = resolutionMap
+											hasRuntimeData = true
+										}
+									}
 									if perms, ok := rtMap["permissions"]; ok && perms != nil {
 										var ps []string
 										for _, p := range perms.([]interface{}) {
@@ -1003,6 +1019,18 @@ func flattenProxyTransforms(transforms []*basistheory.ProxyTransform) []map[stri
 					}
 					if len(deps) > 0 {
 						rtMap["dependencies"] = deps
+						hasRuntimeData = true
+					}
+				}
+				if rt.Resolutions != nil && len(rt.Resolutions) > 0 {
+					resolutions := map[string]string{}
+					for k, p := range rt.Resolutions {
+						if p != nil {
+							resolutions[k] = *p
+						}
+					}
+					if len(resolutions) > 0 {
+						rtMap["resolutions"] = resolutions
 						hasRuntimeData = true
 					}
 				}

--- a/internal/provider/resource_basistheory_proxy_test.go
+++ b/internal/provider/resource_basistheory_proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	basistheory "github.com/Basis-Theory/go-sdk/v5"
@@ -15,6 +16,80 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func TestProxyFinalStateDiagnostics_withoutRequestedError(t *testing.T) {
+	actual := proxyFinalStateDiagnostics("prx_123", "failed", &basistheory.Proxy{})
+
+	if len(actual) != 1 {
+		t.Fatalf("expected one diagnostic, got %d", len(actual))
+	}
+
+	expected := "proxy prx_123 reached failed state"
+	if actual[0].Summary != expected {
+		t.Fatalf("expected %q, got %q", expected, actual[0].Summary)
+	}
+}
+
+func TestProxyFinalStateDiagnostics_usesActualFinalState(t *testing.T) {
+	actual := proxyFinalStateDiagnostics("prx_123", "outdated", &basistheory.Proxy{})
+
+	if len(actual) != 1 {
+		t.Fatalf("expected one diagnostic, got %d", len(actual))
+	}
+
+	expected := "proxy prx_123 reached outdated state"
+	if actual[0].Summary != expected {
+		t.Fatalf("expected %q, got %q", expected, actual[0].Summary)
+	}
+}
+
+func TestProxyFinalStateDiagnostics_includesRequestedError(t *testing.T) {
+	errorCode := "vulnerabilities_detected"
+	errorMessage := "Please update the dependencies listed to resolve security vulnerabilities."
+	proxy := &basistheory.Proxy{
+		Requested: &basistheory.RequestedProxy{
+			ErrorCode:    &errorCode,
+			ErrorMessage: &errorMessage,
+			ErrorDetails: map[string]interface{}{
+				"vulnerabilities": []interface{}{
+					map[string]interface{}{
+						"name":            "follow-redirects",
+						"version":         "1.14.7",
+						"severity":        "HIGH",
+						"id":              "CVE-2022-0536",
+						"dependency_path": []interface{}{"axios", "follow-redirects"},
+					},
+				},
+			},
+		},
+	}
+
+	actual := proxyFinalStateDiagnostics("prx_123", "outdated", proxy)
+
+	if len(actual) != 1 {
+		t.Fatalf("expected one diagnostic, got %d", len(actual))
+	}
+
+	expectedParts := []string{
+		"proxy prx_123 reached outdated state",
+		"Requested Proxy Error Code: vulnerabilities_detected",
+		"Requested Proxy Error Message: Please update the dependencies listed to resolve security vulnerabilities.",
+		"Requested Proxy Error Details:",
+		"\"name\": \"follow-redirects\"",
+		"\"version\": \"1.14.7\"",
+		"\"severity\": \"HIGH\"",
+		"\"id\": \"CVE-2022-0536\"",
+		"\"dependency_path\": [",
+		"\"axios\"",
+		"\"follow-redirects\"",
+	}
+
+	for _, expectedPart := range expectedParts {
+		if !strings.Contains(actual[0].Summary, expectedPart) {
+			t.Fatalf("expected diagnostic to contain %q, got %q", expectedPart, actual[0].Summary)
+		}
+	}
+}
 
 func TestResourceProxy(t *testing.T) {
 	skipForVaultApiCaching(t)

--- a/internal/provider/resource_basistheory_proxy_test.go
+++ b/internal/provider/resource_basistheory_proxy_test.go
@@ -14,6 +14,7 @@ import (
 	basistheoryClient "github.com/Basis-Theory/go-sdk/v5/client"
 	"github.com/Basis-Theory/go-sdk/v5/option"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -88,6 +89,68 @@ func TestProxyFinalStateDiagnostics_includesRequestedError(t *testing.T) {
 		if !strings.Contains(actual[0].Summary, expectedPart) {
 			t.Fatalf("expected diagnostic to contain %q, got %q", expectedPart, actual[0].Summary)
 		}
+	}
+}
+
+func TestGetProxyFromData_includesRuntimeResolutions(t *testing.T) {
+	data := schema.TestResourceDataRaw(t, resourceBasisTheoryProxy().Schema, map[string]interface{}{
+		"name":            "Terraform proxy with node 22 runtime",
+		"destination_url": "https://httpbin.org/post",
+		"request_transforms": []interface{}{
+			map[string]interface{}{
+				"type": "code",
+				"code": "module.exports = async function (context) { return context; };",
+				"options": []interface{}{
+					map[string]interface{}{
+						"runtime": []interface{}{
+							map[string]interface{}{
+								"image": "node22",
+								"dependencies": map[string]interface{}{
+									"axios": "1.15.1",
+								},
+								"resolutions": map[string]interface{}{
+									"follow-redirects": "1.15.6",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	proxy := getProxyFromData(data)
+
+	if len(proxy.RequestTransforms) != 1 {
+		t.Fatalf("expected one request transform, got %d", len(proxy.RequestTransforms))
+	}
+
+	resolutions := proxy.RequestTransforms[0].Options.Runtime.Resolutions
+	if actual := resolutions["follow-redirects"]; actual == nil || *actual != "1.15.6" {
+		t.Fatalf("expected follow-redirects resolution to be 1.15.6, got %v", actual)
+	}
+}
+
+func TestFlattenProxyTransforms_includesRuntimeResolutions(t *testing.T) {
+	transforms := []*basistheory.ProxyTransform{
+		{
+			Options: &basistheory.ProxyTransformOptions{
+				Runtime: &basistheory.Runtime{
+					Resolutions: map[string]*string{
+						"follow-redirects": getStringPointer("1.15.6"),
+					},
+				},
+			},
+		},
+	}
+
+	flattened := flattenProxyTransforms(transforms)
+
+	options := flattened[0]["options"].([]interface{})[0].(map[string]interface{})
+	runtime := options["runtime"].([]interface{})[0].(map[string]interface{})
+	resolutions := runtime["resolutions"].(map[string]string)
+	if actual := resolutions["follow-redirects"]; actual != "1.15.6" {
+		t.Fatalf("expected follow-redirects resolution to be 1.15.6, got %q", actual)
 	}
 }
 
@@ -239,6 +302,8 @@ func TestResourceProxyWithNode22Runtimes(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"basistheory_proxy.terraform_test_proxy", "request_transforms.0.options.0.runtime.0.dependencies.@basis-theory/node-sdk", "4.2.1"),
 					resource.TestCheckResourceAttr(
+						"basistheory_proxy.terraform_test_proxy", "request_transforms.0.options.0.runtime.0.resolutions.follow-redirects", "1.15.6"),
+					resource.TestCheckResourceAttr(
 						"basistheory_proxy.terraform_test_proxy", "request_transforms.0.options.0.runtime.0.warm_concurrency", "1"),
 					resource.TestCheckResourceAttr(
 						"basistheory_proxy.terraform_test_proxy", "request_transforms.0.options.0.runtime.0.timeout", "10"),
@@ -251,6 +316,8 @@ func TestResourceProxyWithNode22Runtimes(t *testing.T) {
 						"basistheory_proxy.terraform_test_proxy", "response_transforms.0.options.0.runtime.0.image", "node22"),
 					resource.TestCheckResourceAttr(
 						"basistheory_proxy.terraform_test_proxy", "response_transforms.0.options.0.runtime.0.dependencies.@basis-theory/node-sdk", "4.2.1"),
+					resource.TestCheckResourceAttr(
+						"basistheory_proxy.terraform_test_proxy", "response_transforms.0.options.0.runtime.0.resolutions.follow-redirects", "1.15.6"),
 					resource.TestCheckResourceAttr(
 						"basistheory_proxy.terraform_test_proxy", "response_transforms.0.options.0.runtime.0.warm_concurrency", "1"),
 					resource.TestCheckResourceAttr(
@@ -1048,6 +1115,9 @@ resource "basistheory_proxy" "terraform_test_proxy" {
         dependencies = {
           "@basis-theory/node-sdk" = "4.2.1"
         }
+        resolutions = {
+          "follow-redirects" = "1.15.6"
+        }
         warm_concurrency = 1
         timeout = 10
         resources = "standard"
@@ -1067,6 +1137,9 @@ resource "basistheory_proxy" "terraform_test_proxy" {
         image = "node22"
         dependencies = {
           "@basis-theory/node-sdk" = "4.2.1"
+        }
+        resolutions = {
+          "follow-redirects" = "1.15.6"
         }
         warm_concurrency = 1
         timeout = 10

--- a/internal/provider/resource_basistheory_reactor.go
+++ b/internal/provider/resource_basistheory_reactor.go
@@ -80,6 +80,14 @@ func resourceBasisTheoryReactor() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
+						"resolutions": {
+							Description: "Runtime dependency resolutions",
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
 						"warm_concurrency": {
 							Description: "Warm concurrency setting",
 							Type:        schema.TypeInt,
@@ -271,6 +279,15 @@ func resourceReactorRead(ctx context.Context, data *schema.ResourceData, meta in
 			}
 			runtimeMap["dependencies"] = deps
 		}
+		if v := runtime.Resolutions; v != nil {
+			resolutions := map[string]string{}
+			for k, p := range v {
+				if p != nil {
+					resolutions[k] = *p
+				}
+			}
+			runtimeMap["resolutions"] = resolutions
+		}
 		if v := runtime.WarmConcurrency; v != nil {
 			runtimeMap["warm_concurrency"] = *v
 		}
@@ -409,6 +426,14 @@ func getReactorFromData(data *schema.ResourceData) *basistheory.Reactor {
 						depMap[k] = getStringPointer(v)
 					}
 					rt.Dependencies = depMap
+				}
+				// resolutions map[string]string -> map[string]*string
+				if resolutions, ok := m["resolutions"]; ok && resolutions != nil {
+					resolutionMap := map[string]*string{}
+					for k, v := range resolutions.(map[string]interface{}) {
+						resolutionMap[k] = getStringPointer(v)
+					}
+					rt.Resolutions = resolutionMap
 				}
 				// permissions []interface{} -> []string
 				if perms, ok := m["permissions"]; ok && perms != nil {

--- a/internal/provider/resource_basistheory_reactor.go
+++ b/internal/provider/resource_basistheory_reactor.go
@@ -59,14 +59,14 @@ func resourceBasisTheoryReactor() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-   "runtime": {
-                Description: "Runtime configuration for the Reactor",
-                Type:        schema.TypeList,
-                Optional:    true,
-                Computed:    true,
-                MaxItems:    1,
-                Elem: &schema.Resource{
-                    Schema: map[string]*schema.Schema{
+			"runtime": {
+				Description: "Runtime configuration for the Reactor",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
 						"image": {
 							Description: "Runtime image (e.g., node22)",
 							Type:        schema.TypeString,
@@ -140,7 +140,7 @@ func resourceReactorCreate(ctx context.Context, data *schema.ResourceData, meta 
 
 	reactor := getReactorFromData(data)
 
- createReactorRequest := &basistheory.CreateReactorRequest{
+	createReactorRequest := &basistheory.CreateReactorRequest{
 		Name:          getStringValue(reactor.Name),
 		Code:          getStringValue(reactor.Code),
 		Configuration: reactor.Configuration,
@@ -188,7 +188,7 @@ func waitForReactorFinalState(ctx context.Context, client *basistheoryClient.Cli
 		case "active":
 			return nil
 		case "failed", "outdated":
-			return diag.Errorf("reactor %s reached failed state", id)
+			return reactorFinalStateDiagnostics(id, state, reactor)
 		}
 
 		select {
@@ -197,6 +197,33 @@ func waitForReactorFinalState(ctx context.Context, client *basistheoryClient.Cli
 		case <-time.After(interval):
 		}
 	}
+}
+
+func reactorFinalStateDiagnostics(id string, state string, reactor *basistheory.Reactor) diag.Diagnostics {
+	message := "reactor %s reached %s state"
+	errorArgs := []interface{}{id, state}
+
+	requested := reactor.GetRequested()
+	if requested == nil {
+		return diag.Errorf(message, errorArgs...)
+	}
+
+	if errorCode := requested.GetErrorCode(); errorCode != nil && *errorCode != "" {
+		message += "\n\tRequested Reactor Error Code: %s"
+		errorArgs = append(errorArgs, *errorCode)
+	}
+
+	if errorMessage := requested.GetErrorMessage(); errorMessage != nil && *errorMessage != "" {
+		message += "\n\tRequested Reactor Error Message: %s"
+		errorArgs = append(errorArgs, *errorMessage)
+	}
+
+	if errorDetails := requested.GetErrorDetails(); len(errorDetails) > 0 {
+		message += "\n\tRequested Reactor Error Details: %s"
+		errorArgs = append(errorArgs, formatRequestedErrorDetails(errorDetails))
+	}
+
+	return diag.Errorf(message, errorArgs...)
 }
 
 func resourceReactorRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -299,7 +326,7 @@ func resourceReactorUpdate(ctx context.Context, data *schema.ResourceData, meta 
 	basisTheoryClient := meta.(map[string]interface{})["client"].(*basistheoryClient.Client)
 
 	reactor := getReactorFromData(data)
- updateReactorRequest := &basistheory.UpdateReactorRequest{
+	updateReactorRequest := &basistheory.UpdateReactorRequest{
 		Name:          getStringValue(reactor.Name),
 		Code:          getStringValue(reactor.Code),
 		Configuration: reactor.Configuration,

--- a/internal/provider/resource_basistheory_reactor_test.go
+++ b/internal/provider/resource_basistheory_reactor_test.go
@@ -13,6 +13,7 @@ import (
 	basistheoryClient "github.com/Basis-Theory/go-sdk/v5/client"
 	"github.com/Basis-Theory/go-sdk/v5/option"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -87,6 +88,31 @@ func TestReactorFinalStateDiagnostics_includesRequestedError(t *testing.T) {
 		if !strings.Contains(actual[0].Summary, expectedPart) {
 			t.Fatalf("expected diagnostic to contain %q, got %q", expectedPart, actual[0].Summary)
 		}
+	}
+}
+
+func TestGetReactorFromData_includesRuntimeResolutions(t *testing.T) {
+	data := schema.TestResourceDataRaw(t, resourceBasisTheoryReactor().Schema, map[string]interface{}{
+		"name": "Terraform reactor with node22 runtime",
+		"code": "module.exports = async function (context) { return context; };",
+		"runtime": []interface{}{
+			map[string]interface{}{
+				"image": "node22",
+				"dependencies": map[string]interface{}{
+					"axios": "1.15.1",
+				},
+				"resolutions": map[string]interface{}{
+					"follow-redirects": "1.15.6",
+				},
+			},
+		},
+	})
+
+	reactor := getReactorFromData(data)
+
+	resolutions := reactor.Runtime.Resolutions
+	if actual := resolutions["follow-redirects"]; actual == nil || *actual != "1.15.6" {
+		t.Fatalf("expected follow-redirects resolution to be 1.15.6, got %v", actual)
 	}
 }
 
@@ -180,6 +206,8 @@ func TestResourceReactorWithNode22Runtime(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"basistheory_reactor.terraform_test_reactor_node22", "runtime.0.dependencies.@basis-theory/node-sdk", "4.2.1"),
 					resource.TestCheckResourceAttr(
+						"basistheory_reactor.terraform_test_reactor_node22", "runtime.0.resolutions.follow-redirects", "1.15.6"),
+					resource.TestCheckResourceAttr(
 						"basistheory_reactor.terraform_test_reactor_node22", "runtime.0.warm_concurrency", "1"),
 					resource.TestCheckResourceAttr(
 						"basistheory_reactor.terraform_test_reactor_node22", "runtime.0.timeout", "10"),
@@ -200,6 +228,10 @@ func TestResourceReactorWithNode22Runtime(t *testing.T) {
 						"basistheory_reactor.terraform_test_reactor_node22", "runtime.0.dependencies.@basis-theory/node-sdk", "4.2.1"),
 					resource.TestCheckResourceAttr(
 						"basistheory_reactor.terraform_test_reactor_node22", "runtime.0.dependencies.is-odd", "3.0.1"),
+					resource.TestCheckResourceAttr(
+						"basistheory_reactor.terraform_test_reactor_node22", "runtime.0.resolutions.follow-redirects", "1.15.6"),
+					resource.TestCheckResourceAttr(
+						"basistheory_reactor.terraform_test_reactor_node22", "runtime.0.resolutions.is-number", "7.0.0"),
 				),
 			},
 		},
@@ -279,6 +311,9 @@ resource "basistheory_reactor" "%s" {
 	 dependencies = {
 		"@basis-theory/node-sdk" = "4.2.1"
 	 }
+	 resolutions = {
+		"follow-redirects" = "1.15.6"
+	 }
      warm_concurrency = 1
      timeout = 10
      resources = "standard"
@@ -312,6 +347,10 @@ resource "basistheory_reactor" "%s" {
 	 dependencies = {
 		"@basis-theory/node-sdk" = "4.2.1"
 		"is-odd" = "3.0.1"
+	 }
+	 resolutions = {
+		"follow-redirects" = "1.15.6"
+		"is-number" = "7.0.0"
 	 }
      warm_concurrency = 1
      timeout = 10

--- a/internal/provider/resource_basistheory_reactor_test.go
+++ b/internal/provider/resource_basistheory_reactor_test.go
@@ -4,15 +4,91 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
 	basistheory "github.com/Basis-Theory/go-sdk/v5"
 	basistheoryClient "github.com/Basis-Theory/go-sdk/v5/client"
 	"github.com/Basis-Theory/go-sdk/v5/option"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"os"
-	"regexp"
-	"testing"
 )
+
+func TestReactorFinalStateDiagnostics_withoutRequestedError(t *testing.T) {
+	actual := reactorFinalStateDiagnostics("rct_123", "failed", &basistheory.Reactor{})
+
+	if len(actual) != 1 {
+		t.Fatalf("expected one diagnostic, got %d", len(actual))
+	}
+
+	expected := "reactor rct_123 reached failed state"
+	if actual[0].Summary != expected {
+		t.Fatalf("expected %q, got %q", expected, actual[0].Summary)
+	}
+}
+
+func TestReactorFinalStateDiagnostics_usesActualFinalState(t *testing.T) {
+	actual := reactorFinalStateDiagnostics("rct_123", "outdated", &basistheory.Reactor{})
+
+	if len(actual) != 1 {
+		t.Fatalf("expected one diagnostic, got %d", len(actual))
+	}
+
+	expected := "reactor rct_123 reached outdated state"
+	if actual[0].Summary != expected {
+		t.Fatalf("expected %q, got %q", expected, actual[0].Summary)
+	}
+}
+
+func TestReactorFinalStateDiagnostics_includesRequestedError(t *testing.T) {
+	errorCode := "vulnerabilities_detected"
+	errorMessage := "Please update the dependencies listed to resolve security vulnerabilities."
+	reactor := &basistheory.Reactor{
+		Requested: &basistheory.RequestedReactor{
+			ErrorCode:    &errorCode,
+			ErrorMessage: &errorMessage,
+			ErrorDetails: map[string]interface{}{
+				"vulnerabilities": []interface{}{
+					map[string]interface{}{
+						"name":            "follow-redirects",
+						"version":         "1.14.7",
+						"severity":        "HIGH",
+						"id":              "CVE-2022-0536",
+						"dependency_path": []interface{}{"axios", "follow-redirects"},
+					},
+				},
+			},
+		},
+	}
+
+	actual := reactorFinalStateDiagnostics("rct_123", "outdated", reactor)
+
+	if len(actual) != 1 {
+		t.Fatalf("expected one diagnostic, got %d", len(actual))
+	}
+
+	expectedParts := []string{
+		"reactor rct_123 reached outdated state",
+		"Requested Reactor Error Code: vulnerabilities_detected",
+		"Requested Reactor Error Message: Please update the dependencies listed to resolve security vulnerabilities.",
+		"Requested Reactor Error Details:",
+		"\"name\": \"follow-redirects\"",
+		"\"version\": \"1.14.7\"",
+		"\"severity\": \"HIGH\"",
+		"\"id\": \"CVE-2022-0536\"",
+		"\"dependency_path\": [",
+		"\"axios\"",
+		"\"follow-redirects\"",
+	}
+
+	for _, expectedPart := range expectedParts {
+		if !strings.Contains(actual[0].Summary, expectedPart) {
+			t.Fatalf("expected diagnostic to contain %q, got %q", expectedPart, actual[0].Summary)
+		}
+	}
+}
 
 func TestResourceReactor(t *testing.T) {
 	testAccApplicationName := "terraform_test_application_reactor_test"
@@ -129,7 +205,6 @@ func TestResourceReactorWithNode22Runtime(t *testing.T) {
 		},
 	})
 }
-
 
 const testAccReactorCreate = `
 resource "basistheory_reactor" "%s" {


### PR DESCRIPTION
## Description

- Include requested provisioning error code, message, and details when proxy or reactor polling reaches `failed` or `outdated`
- Add `runtime.resolutions` support for proxy request transform runtimes, proxy response transform runtimes, and reactor runtimes
- Bump `github.com/Basis-Theory/go-sdk/v5` to `v5.10.0` and adjust the Apple Pay merchant certificate request shape required by that SDK
- Update provider docs for the new runtime field

## Testing required outside of automated testing?

- [x] Not Applicable

Local validation:

```bash
go build ./...
go test ./internal/provider -count=1 -run 'Test(Proxy|Reactor)FinalStateDiagnostics|TestGet(Proxy|Reactor)FromData_includesRuntimeResolutions|TestFlattenProxyTransforms_includesRuntimeResolutions'
git diff --check
```

### Screenshots (if appropriate):

- [x] Not Applicable

## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

Roll forward with a follow-up provider patch if the diagnostic formatting or runtime field mapping needs adjustment.

## Reviewer Checklist

- [x] Description of Change
- [x] Description of outside testing if applicable.
- [x] Description of Roll Forward / Backward Procedure
- [x] Documentation updated for Change
